### PR TITLE
Fixes

### DIFF
--- a/vars.c
+++ b/vars.c
@@ -48,7 +48,9 @@ u8 meshtid[MESH_CNT];
 
 u8 textureheader[256][4],texturereload[256];
 u16 texturedata[1048576*5/2];
-u32 texturepointer[128];
+//senquack - should be [256], judging from its use in zrmloadtextures() in zresm.c:
+//u32 texturepointer[128];
+u32 texturepointer[256];
 
 u16 meshcount;
 

--- a/vars.h
+++ b/vars.h
@@ -46,7 +46,9 @@ extern u8 meshtid[MESH_CNT];
 
 extern u8 textureheader[256][4],texturereload[256];
 extern u16 texturedata[1048576*5/2];
-extern u32 texturepointer[128];
+//senquack - should be [256], judging from its use in zrmloadtextures() in zresm.c:
+//extern u32 texturepointer[128];
+extern u32 texturepointer[256];
 
 extern u16 meshcount;
 

--- a/zcore.c
+++ b/zcore.c
@@ -275,7 +275,7 @@ void zcore_video_init(void)
 #if defined(GCW)
 
 ////////////////////////////////////////////////////////////////////////////////////////
-   screen=SDL_SetVideoMode(320,240,16, SDL_OPENGL);
+   screen=SDL_SetVideoMode(320,240,16, SDL_SWSURFACE);
 
    const char* output;
 


### PR DESCRIPTION
Fix size of texturepointer[] array

Fix SDL video mode flag (Only use SDL_OPENGL if you are using SDL's OpenGL1.2 driver, not when you are using EGL as you do on GCW Zero)
